### PR TITLE
Update affiliation of an area chair.

### DIFF
--- a/committee.html
+++ b/committee.html
@@ -39,7 +39,7 @@ navigation_weight: 4
     <li>Yarin Gal    (University of Cambridge) </li>
     <li>Manuel Gomez Rodriguez    (Max Planck Institute for Software Systems) </li>
     <li>Noah Goodman    (Stanford University) </li>
-    <li>Matthew Graham    (University of Edinburgh) </li>
+    <li>Matthew Graham    (National University of Singapore) </li>
     <li>Michael Gutmann    (University of Edinburgh) </li>
     <li>Stefan Harmeling    (HHU) </li>
     <li>Nicolas Heess    (DeepMind) </li>


### PR DESCRIPTION
Not important, but just noticed I am listed as being affiliated with University of Edinburgh (which makes sense as I still was when this page was created!). Pull request updates my affiliation to NUS.