### PR TITLE
Update index.md to link to 2026

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,4 +3,4 @@ layout: default
 title: Home
 ---
 
-The Society organises annual meetings where researchers gather to share their ideas. The next meeting will be held in 2025. Details can be found [on this page](http://aistats.org/aistats2025/).
+The Society organises annual meetings where researchers gather to share their ideas. The next meeting will be held in 2026. Details can be found [on this page](http://aistats.org/aistats2026/).


### PR DESCRIPTION
Updating the main site aistats.org to link to the 2026 edition of the conference.